### PR TITLE
Fix a bug on CUDA availability check

### DIFF
--- a/coordconv.py
+++ b/coordconv.py
@@ -24,7 +24,7 @@ class AddCoords(nn.Module):
             xx_channel = xx_channel * 2 - 1
             xx_channel = xx_channel.repeat(batch_size_shape, 1, 1)
 
-            if torch.cuda.is_available and self.use_cuda:
+            if torch.cuda.is_available() and self.use_cuda:
                 input_tensor = input_tensor.cuda()
                 xx_channel = xx_channel.cuda()
             out = torch.cat([input_tensor, xx_channel], dim=1)
@@ -58,7 +58,7 @@ class AddCoords(nn.Module):
             xx_channel = xx_channel.repeat(batch_size_shape, 1, 1, 1)
             yy_channel = yy_channel.repeat(batch_size_shape, 1, 1, 1)
 
-            if torch.cuda.is_available and self.use_cuda:
+            if torch.cuda.is_available() and self.use_cuda:
                 input_tensor = input_tensor.cuda()
                 xx_channel = xx_channel.cuda()
                 yy_channel = yy_channel.cuda()
@@ -97,7 +97,7 @@ class AddCoords(nn.Module):
             zz_channel = torch.cat([zx_channel + i for i in range(dim_y)], dim=3)
             zz_channel = zz_channel.repeat(batch_size_shape, 1, 1, 1, 1)
 
-            if torch.cuda.is_available and self.use_cuda:
+            if torch.cuda.is_available() and self.use_cuda:
                 input_tensor = input_tensor.cuda()
                 xx_channel = xx_channel.cuda()
                 yy_channel = yy_channel.cuda()


### PR DESCRIPTION
`torch.cuda.is_available` was not called correctly.

original:
```python
if torch.cuda.is_available and ...:
```

fixed:
```python
if torch.cuda.is_available() and ...:
```
